### PR TITLE
Add HUNT token

### DIFF
--- a/data/HUNT/data.json
+++ b/data/HUNT/data.json
@@ -1,0 +1,11 @@
+{
+  "name": "HuntToken",
+  "symbol": "HUNT",
+  "decimals": 18,
+  "logoURI": "https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/master/data/HUNT/logo.svg",
+  "opTokenId": "HUNT",
+  "addresses": {
+    "1": "0x9AAb071B4129B083B01cB5A0Cb513Ce7ecA26fa5",
+    "8453": "0x37f0c2915CeCC7e977183B8543Fc0864d03E064C"
+  }
+}


### PR DESCRIPTION
Add HUNT Token on Base

- Website: https://hunt.town
- Description: Hunt Town is a Web3 builders guild where builders come together to contribute to the expansion of Web3 culture and products.
- Twitter: [@steemhunt](https://twitter.com/steemhunt)

Contracts:
- Ethereum: https://etherscan.io/token/0x9aab071b4129b083b01cb5a0cb513ce7eca26fa5
- Base: https://basescan.org/token/0x37f0c2915CeCC7e977183B8543Fc0864d03E064C
