### PR TITLE
Add UDT token on BAse, Optimism and test nets

### DIFF
--- a/data/UDT/data.json
+++ b/data/UDT/data.json
@@ -1,6 +1,4 @@
 {
-
-
   "name": "Unlock Discount Token",
   "symbol": "UDT",
   "decimals": 18,

--- a/data/UDT/data.json
+++ b/data/UDT/data.json
@@ -1,0 +1,18 @@
+{
+
+
+  "name": "Unlock Discount Token",
+  "symbol": "UDT",
+  "decimals": 18,
+  "description": "Governance token for Unlock Protocol, a protocol for creating memberships and subscriptions as NFTs",
+  "logoURI": "https://raw.githubusercontent.com/unlock-protocol/unlock/master/design/logo/%C9%84nlock-Logo-symbol-round-beige.svg",
+  "website": "https://unlock-protocol.com",
+  "twitter": "@unlockprotocol",
+  "addresses": {
+    "1": "0x90DE74265a416e1393A450752175AED98fe11517",
+    "10": "0xc709c9116dBf29Da9c25041b13a07A0e68aC5d2D",
+    "11155111": "0x447B1492C5038203f1927eB2a374F5Fcdc25999d",    
+    "8453": "0xD7eA82D19f1f59FF1aE95F1945Ee6E6d86A25B96",
+    "84532": "0x68a8011d72E6D41bf7CE9dC49De0aeaEBAAC9b39"
+  }
+}


### PR DESCRIPTION
## Add UDT Token on Base

Website: https://unlock-protocol.com/
Description: Governance token for Unlock Protocol, a protocol for creating memberships and subscriptions as NFTs
Twitter: [@unlockprotocol](https://twitter.com/unlockprotocol)
Contracts:

Ethereum: https://etherscan.io/token/0x90DE74265a416e1393A450752175AED98fe11517
Base: https://basescan.org/token/0xD7eA82D19f1f59FF1aE95F1945Ee6E6d86A25B96
Optimism: https://basescan.org/token/0xc709c9116dBf29Da9c25041b13a07A0e68aC5d2D