### PR TITLE
Add PSTAKE token

### DIFF
--- a/data/PSTAKE/data.json
+++ b/data/PSTAKE/data.json
@@ -1,0 +1,11 @@
+{
+    "name": "pSTAKE Finance",
+    "symbol": "PSTAKE",
+    "decimals": 18,
+    "logoURI": "https://github.com/SmolDapp/tokenAssets/blob/main/tokens/8453/0x38815a4455921667d673b4cb3d48f0383ee93400/logo.svg",
+    "opTokenId": "PSTAKE",
+    "addresses": {
+      "1": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+      "8453": "0x38815A4455921667d673B4cb3d48F0383eE93400"
+    }
+}

--- a/data/PSTAKE/data.json
+++ b/data/PSTAKE/data.json
@@ -2,7 +2,7 @@
     "name": "pSTAKE Finance",
     "symbol": "PSTAKE",
     "decimals": 18,
-    "logoURI": "https://github.com/SmolDapp/tokenAssets/blob/main/tokens/8453/0x38815a4455921667d673b4cb3d48f0383ee93400/logo.svg",
+    "logoURI": "https://raw.githubusercontent.com/SmolDapp/tokenAssets/907ff615dedb497f21eee3b152917121a2131e8f/tokens/8453/0x38815a4455921667d673b4cb3d48f0383ee93400/logo.svg",
     "opTokenId": "PSTAKE",
     "addresses": {
       "1": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",


### PR DESCRIPTION
Add PSTAKE Token on Base

- Website: https://pstake.finance/
- Description: pSTAKE Finance is a multichain liquid staking protocol for BNB Chain, Solana, Cosmos, and beyond, backed by Binance Labs.
- Twitter: [@pStakeFinance](https://twitter.com/pStakeFinance)

Contracts:

- Ethereum: https://etherscan.io/token/0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006
- Base: https://basescan.org/token/0x38815A4455921667d673B4cb3d48F0383eE93400

@njokuScript 