### PR TITLE
feat: 🎸 Added SLN token for chains 1,10,8453,185

### DIFF
--- a/data/SLN/data.json
+++ b/data/SLN/data.json
@@ -10,7 +10,6 @@
 	"addresses": {
 		"1": "0xDb82c0d91E057E05600C8F8dc836bEb41da6df14",
 		"10": "0xbCB49FcB41899E31e442a4D7439964966e0C9B28",
-		"8453": "0xef0b105b4f2ce61d2a7ae62d03b1f4cb6c4fbeec",
-		"185": "0xa356c6c6dc0fec7eb14778269fa4fc38a4fb3d1f"
+		"8453": "0xef0b105b4f2ce61d2a7ae62d03b1f4cb6c4fbeec"
 	}
 }

--- a/data/SLN/data.json
+++ b/data/SLN/data.json
@@ -1,0 +1,16 @@
+{
+	"name": "Smart Layer Network Token",
+	"symbol": "SLN",
+	"decimals": 18,
+	"description": "Smart Layer brings Smart Tokens ( Executable Tokens and NFTs ) enabled by ERC-5169 and TokenScript. SLN is Smart Layer Network's primary token",
+	"logoURI": "https://www.smartlayer.network/icon-white.png",
+	"website": "https://smartlayer.network",
+	"twitter": "@SmartLayer",
+	"opTokenId": "SLN",
+	"addresses": {
+		"1": "0xDb82c0d91E057E05600C8F8dc836bEb41da6df14",
+		"10": "0xbCB49FcB41899E31e442a4D7439964966e0C9B28",
+		"8453": "0xef0b105b4f2ce61d2a7ae62d03b1f4cb6c4fbeec",
+		"185": "0xa356c6c6dc0fec7eb14778269fa4fc38a4fb3d1f"
+	}
+}


### PR DESCRIPTION
Please add SLN Token on ETH, Optimism, BASE, (MINT removed because its not supported by test scripts)
Website: https://smartlayer.network
Description: Smart Layer brings Smart Tokens ( Executable Tokens and NFTs ) enabled by ERC-5169 and TokenScript. SLN is Smart Layer Network's primary token

LinkedIn: https://www.linkedin.com/company/smart-token-labs/
Twitter: https://twitter.com/SmartLayer
Madium: https://medium.com/alphawallet

KUCOIN - https://www.kucoin.com/trade/SLN-USDT

Hello, @njokuScript, could you help to review and merge? 
Thank you in advance.
