### PR TITLE
Updated pStake logo URI

### DIFF
--- a/data/PSTAKE/data.json
+++ b/data/PSTAKE/data.json
@@ -2,7 +2,7 @@
     "name": "pSTAKE Finance",
     "symbol": "PSTAKE",
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/SmolDapp/tokenAssets/907ff615dedb497f21eee3b152917121a2131e8f/tokens/8453/0x38815a4455921667d673b4cb3d48f0383ee93400/logo.svg",
+    "logoURI": "https://raw.githubusercontent.com/persistencedotone/persistence-assets/main/pStake.svg",
     "opTokenId": "PSTAKE",
     "addresses": {
       "1": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",


### PR DESCRIPTION
## Add PSTAKE Token on Optimism

- Website: https://pstake.finance/
- Description: pSTAKE Finance is a Bitcoin Yield and liquid staking protocol, backed by Binance Labs.
- Twitter: [@pStakeFinance](https://twitter.com/pStakeFinance)

### Contracts:

- Ethereum: https://etherscan.io/token/0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006
- Optimism: https://optimistic.etherscan.io/token/0x023550ADDe4FA2F90D63a41D9282BEE0294c04cD

@njokuScript