### PR TITLE
Add IPOR to superbridge

### DIFF
--- a/data/IPOR/data.json
+++ b/data/IPOR/data.json
@@ -1,0 +1,16 @@
+{
+  "name": "IPOR Token",
+  "symbol": "IPOR",
+  "decimals": 18,
+  "description": "The IPOR token is the protocol's native token issued to the parties involved with the project: builders, investors, liquidity providers, and the like.",
+  "website": "https://ipor.io",
+  "twitter": "https://x.com/ipor_io",
+  "logoURI": "https://assets.coingecko.com/coins/images/28373/large/IPOR-token-200x200.png",
+  "opTokenId": "IPOR",
+  "addresses": {
+    "1": "0x1e4746dC744503b53b4A082cB3607B169a289090",
+    "8453": "0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a",
+    "11155111": "0x6e14233172B25eba7Ed3CBC513dD8d78d7c2F519",
+    "84532": "0x7EbbA0361cCF8ECF66C4522A9323674Cd33e8b99"
+  }
+}


### PR DESCRIPTION
Add `IPOR Token` on `Ethereum`, `Base`, `Sepolia` and `Base Sepolia`.

- Website: https://ipor.io
- Description: The IPOR token is the protocol's native token issued to the parties involved with the project: builders, investors, liquidity providers, and the like.
- Twitter/X: [@ipor_io](https://x.com/ipor_io)

Contracts:

- Ethereum: https://etherscan.io/token/0x1e4746dC744503b53b4A082cB3607B169a289090
- Base: https://basescan.org/token/0xbd4e5c2f8de5065993d29a9794e2b7cefc41437a
- Sepolia: https://sepolia.etherscan.io/token/0x6e14233172B25eba7Ed3CBC513dD8d78d7c2F519
- Base Sepolia: https://sepolia.basescan.org/token/0x7EbbA0361cCF8ECF66C4522A9323674Cd33e8b99