### PR TITLE
Add NET (Nektar Network) to token list

### DIFF
--- a/data/NET/data.json
+++ b/data/NET/data.json
@@ -1,0 +1,11 @@
+{
+  "name": "Nektar Network",
+  "symbol": "NET",
+  "decimals": 18,
+  "logoURI": "https://raw.githubusercontent.com/Deepcryptodive/ethereum-optimism.github.io/22e3f194774f4bdff25cc8020c59583c08cde642/data/NET/logo.svg",
+  "opTokenId": "NET",
+  "addresses": {
+    "1": "0x6e6b7adfc7db9feeb8896418ac3422966f65d0a5",
+    "8453": "0x2d1B28672C631CC3CE556D3C7F0E78016E809fec"
+  }
+}


### PR DESCRIPTION
Add NET (Nektar Network) token on Base

Website: https://nektar.network/
Description: Nektar is a Infrastructure Marketplace that aggregates liquidity by connecting Delegators to Networks through a Decentralized Asset Manager (DAM). Nektar has airdropped it's governance token to many DeFi participants in the Base ecosystem, and would like to establish a presence of it's token on Base as well.
Twitter: [@nektarnetwork](https://twitter.com/nektarnetwork)

Contracts:

- Ethereum: https://etherscan.io/token/0x6e6b7adfc7db9feeb8896418ac3422966f65d0a5

- Base: https://basescan.org/token/0x2d1B28672C631CC3CE556D3C7F0E78016E809fec

Please let me know if a verification tweet is necessary. That can be arranged! 

Note: a similar PR has been made to get added into the main OP repo [here](https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/1010).