### PR TITLE
Add NAVI to superbridge

### DIFF
--- a/data/NAVI/data.json
+++ b/data/NAVI/data.json
@@ -1,0 +1,14 @@
+{
+    "name": "Atlas Navi",
+    "symbol": "NAVI",
+    "decimals": 18,
+    "description": "Atlas Navi is the first Drive to Earn navigation app that uses A.I. and the smartphone camera to avoid traffic by detecting road conditions, accidents, traffic in each lane, available parking spaces, police vehicles and rerouting drivers to avoid problematic roads.\r\n\r\nIt features licensed 3D NFT vehicles and a sustainable Drive to Earn mechanism and in-app economy that rewards users for each mile driven.\r\n\r\nAtlas Navi has received a $1,200,000 grant from the European Union to develop its technology over the course of 2 years, starting in December 2019.\r\n\r\nWith over 12 years of transportation software experience, the team and company behind Atlas Navi are among the best in the industry and well positioned to disrupt the navigation app market with A.I. and blockchain technologies.\r\n\r\nAtlas Navi is available to download for free on the Apple App Store and Google Play or by going to www.AtlasNavi.com/download. Join over 1,000,000 drivers already using it to navigate and earn whilst driving.",
+    "website": "https://www.atlasnavi.com/",
+    "twitter": "https://x.com/AtlasNavi",
+    "logoURI": "https://static.wixstatic.com/shapes/abb06c_6e2ad2bb57d84363bdc8c2df8e29a70f.svg",
+    "opTokenId": "NAVI",
+    "addresses": {
+      "1": "0xFc1C93a2507975E98b9d0E9260Ded61A00152BF1",
+      "8453": "0xab1c4dde1dafe4e97e2a9e38eb697466942c4755"
+    }
+  }


### PR DESCRIPTION
Add NAVI to superbridge

Name: Atlas Navi
Symbol: NAVI
Decimals: 18
Website": "https://www.atlasnavi.com/",
Twitter": "https://x.com/AtlasNavi",

Ethereum Explorer: https://etherscan.io/token/0xFc1C93a2507975E98b9d0E9260Ded61A00152BF1
Base Explorer: https://basescan.org/address/0xab1c4dde1dafe4e97e2a9e38eb697466942c4755

Description: Atlas Navi is the first Drive to Earn navigation app that uses A.I. and the smartphone camera to avoid traffic by detecting road conditions, accidents, traffic in each lane, available parking spaces, police vehicles and rerouting drivers to avoid problematic roads. It features licensed 3D NFT vehicles and a sustainable Drive to Earn mechanism and in-app economy that rewards users for each mile driven.

Atlas Navi has received a $1,200,000 grant from the European Union to develop its technology over the course of 2 years, starting in December 2019. With over 12 years of transportation software experience, the team and company behind Atlas Navi are among the best in the industry and well positioned to disrupt the navigation app market with A.I. and blockchain technologies.

Atlas Navi is available to download for free on the Apple App Store and Google Play or by going to www.AtlasNavi.com/download. Join over 1,000,000 drivers already using it to navigate and earn whilst driving.

 Let me know if a tweet is necessary, that can be arranged. 