### PR TITLE
Add BONSAI token

### DIFF
--- a/data/BONSAI/data.json
+++ b/data/BONSAI/data.json
@@ -5,7 +5,7 @@
   "logoURI": "https://assets.coingecko.com/coins/images/35884/standard/White_Logo_%283%29.png",
   "opTokenId": "BONSAI",
   "addresses": {
-    "137": "0x3d2bD0e15829AA5C362a4144FdF4A1112fa29B5c",
+    "137": "0x303b63e785B656ca56ea5A5C1634Ab20C98895e1",
     "8453": "0x474f4cb764df9da079D94052fED39625c147C12C",
     "324": "0xB0588f9A9cADe7CD5f194a5fe77AcD6A58250f82"
   }


### PR DESCRIPTION
Add BONSAI Token on Base, zkSync

Website: https://bonsai.meme
Description: $BONSAI is the agentic currency for Bons(ai) and the leading memecoin on Lens
Twitter: [@bonsaitoken404](https://x.com/bonsaitoken404)
Contracts:

Polygon: https://polygonscan.com/token/0x3d2bD0e15829AA5C362a4144FdF4A1112fa29B5c
Base: https://basescan.org/token/0x474f4cb764df9da079D94052fED39625c147C12C
zkSync: https://era.zksync.network/token/0xb0588f9a9cade7cd5f194a5fe77acd6a58250f82